### PR TITLE
222473_storage_add_return_object

### DIFF
--- a/lib/uiza/api_operation/add.rb
+++ b/lib/uiza/api_operation/add.rb
@@ -7,7 +7,9 @@ module Uiza
         headers = {"Authorization" => Uiza.authorization}
 
         uiza_client = UizaClient.new url, method, headers, params, self::OBJECT_API_DESCRIPTION_LINK[:add]
-        uiza_client.execute_request
+        response = uiza_client.execute_request
+
+        retrieve response.id
       end
     end
   end


### PR DESCRIPTION
## Related Tickets
- https://dev.framgia.com/issues/222473

## What's this PR do ?
- [x] create storage
- [x] github document - create storage
## Library
- N/A
## Impacted Areas in Application
- N/A

## Performance
- N/A

## Checklist
- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
- N/A

## Notes
```
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

params = {
  name: "FTP Uiza edited",
  description: "FTP of Uiza, use for transcode",
  storageType: "ftp",
  host: "your-host",
  port: 21
}

response = Uiza::Entity.add params
response.name
response.host
```