### PR TITLE
222787_create_relation_category

### DIFF
--- a/lib/uiza/api_resource/category_resource.rb
+++ b/lib/uiza/api_resource/category_resource.rb
@@ -20,6 +20,10 @@ module Uiza
       def delete_category id
         Uiza::Category.delete id
       end
+
+      def create_relation_category params
+        Uiza::Category.create_relation params
+      end
     end
   end
 end

--- a/lib/uiza/category.rb
+++ b/lib/uiza/category.rb
@@ -12,7 +12,21 @@ module Uiza
       retrieve: "https://docs.uiza.io/#retrieve-category",
       list: "https://docs.uiza.io/#retrieve-category-list",
       update: "https://docs.uiza.io/#update-category",
-      delete: "https://docs.uiza.io/#delete-category"
+      delete: "https://docs.uiza.io/#delete-category",
+      create_relation: "https://docs.uiza.io/#create-category-relation"
     }.freeze
+
+    class << self
+      def create_relation entity_id, metadata_ids
+        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/media/entity/related/metadata"
+        method = :post
+        headers = {"Authorization" => Uiza.authorization}
+        params = {entityId: entity_id, metadataIds: metadata_ids}
+        description_link = OBJECT_API_DESCRIPTION_LINK[:create_relation]
+
+        uiza_client = UizaClient.new url, method, headers, params, description_link
+        uiza_client.execute_request
+      end
+    end
   end
 end

--- a/spec/uiza/category/create_relation_spec.rb
+++ b/spec/uiza/category/create_relation_spec.rb
@@ -1,0 +1,137 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Category do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::list" do
+    context "API returns code 200" do
+      it "should returns an array of relation" do
+        entity_id = "your-entity-id-01"
+        metadata_ids = ["your-category-id-01", "your-category-id-02"]
+
+        expected_method = :post
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/related/metadata"
+        expected_headers = {"Authorization" => "your-authorization"}
+        expected_body = {entityId: entity_id, metadataIds: metadata_ids}
+        mock_response = {
+          data: [{
+            entityId: "your-entity-id-01",
+            metadataId: "your-category-id-01"
+          }, {
+            entityId: "your-entity-id-01",
+            metadataId: "your-category-id-02"
+          }],
+          code: 200
+        }
+
+        stub_request(expected_method, expected_url)
+          .with(headers: expected_headers, body: expected_body)
+          .to_return(body: mock_response.to_json)
+
+        relations = Uiza::Category.create_relation entity_id, metadata_ids
+
+        expect(relations).to be_a Array
+        expect(relations.first.entityId).to eq "your-entity-id-01"
+        expect(relations.first.metadataId).to eq "your-category-id-01"
+        expect(relations.last.entityId).to eq "your-entity-id-01"
+        expect(relations.last.metadataId).to eq "your-category-id-02"
+
+        expect(WebMock).to have_requested(expected_method, expected_url)
+          .with(headers: expected_headers, body: expected_body)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError,
+          "The request was unacceptable, often due to missing a required parameter."
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError,
+          "No valid API key provided."
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError,
+          "The requested resource doesn't exist."
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError,
+          "The syntax of the request is correct (often cause of wrong parameter)."
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 500, Uiza::Error::InternalServerError,
+          "We had a problem with our server. Try again later."
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError,
+          "The server is overloaded or down for maintenance."
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError,
+          "The error seems to have been caused by the client."
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError,
+          "The server is aware that it has encountered an error."
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError,
+          "Unknow Error."
+      end
+    end
+  end
+
+  def api_return_error_code error_code, error_class, error_message
+    entity_id = "your-entity-id-01"
+    metadata_ids = ["your-category-id-01", "your-category-id-02"]
+
+    expected_method = :post
+    expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/related/metadata"
+    expected_headers = {"Authorization" => "your-authorization"}
+    expected_body = {entityId: entity_id, metadataIds: metadata_ids}
+    mock_response = {
+      code: error_code
+    }
+
+    stub_request(expected_method, expected_url)
+      .with(headers: expected_headers, body: expected_body)
+      .to_return(body: mock_response.to_json)
+
+    expect{Uiza::Category.create_relation entity_id, metadata_ids}.to raise_error do |error|
+      expect(error).to be_a error_class
+      expect(error.description_link).to eq "https://docs.uiza.io/#create-category-relation"
+      expect(error.code).to eq error_code
+      expect(error.message).to eq error_message
+    end
+
+    expect(WebMock).to have_requested(expected_method, expected_url)
+      .with(headers: expected_headers, body: expected_body)
+  end
+end


### PR DESCRIPTION
## Related Tickets

- https://dev.framgia.com/issues/222787

## What's this PR do ?

- [x] Create relation category
- [x] create_relation_category function
- [x] Spec relation category
## Library
*(List gem, library third party add new include version)*

- N/A

## Impacted Areas in Application
- N/A
## Performance

- N/A

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
- N/A

## Notes
```
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"
params = {
            entityId: "your-entity-id-01",
            metadataId: ["your-category-id-01",  "your-category-id-02"]
          }
Uiza::Category.create_relation params
```