### PR TITLE
224309_live_create_and_retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ These APIs used to create and manage live streaming event.
 
 See details [here](https://github.com/uizaio/api-wrapper-ruby/blob/develop/doc/LIVE_STREAMING.md).
 
+```ruby
+require "json"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  live = Uiza::Live.retrieve "your-live-id"
+  puts live.id
+  puts live.name
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
 ## Callback
 Callback used to retrieve an information for Uiza to your server, so you can have a trigger notice about an entity is upload completed and .
 

--- a/doc/LIVE_STREAMING.md
+++ b/doc/LIVE_STREAMING.md
@@ -4,3 +4,118 @@ These APIs used to create and manage live streaming event.
 * When have an Event , you can start it : it's named as `Feed`.
 
 See details [here](https://docs.uiza.io/#live-streaming).
+
+## Create a live event
+These APIs use to create a live streaming and manage the live streaming input (output).
+A live stream can be set up and start later or start right after set up.
+Live Channel Minutes counts when the event starts.
+
+See details [here](https://docs.uiza.io/#create-a-live-event).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+params = {
+  name: "test event",
+  mode: "push",
+  encode: 1,
+  dvr: 1,
+  description: "This is for test event",
+  poster: "https://example.com/poster.jpeg",
+  thumbnail: "https://example.com/poster.jpeg",
+  linkStream: [
+      "https://playlist.m3u8"
+  ],
+  resourceMode: "single"
+}
+
+begin
+  live = Uiza::Live.create params
+  puts live.id
+  puts live.name
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "8b83886e-9cc3-4eab-9258-ebb16c0c73de",
+  "name": "checking 01",
+  "description": "checking",
+  "mode": "pull",
+  "resourceMode": "single",
+  "encode": 0,
+  "channelName": "checking-01",
+  "lastPresetId": null,
+  "lastFeedId": null,
+  "poster": "https://example.com/poster.jpeg",
+  "thumbnail": "https://example.com/thumbnail.jpeg",
+  "linkPublishSocial": null,
+  "linkStream": "[\"https://www.youtube.com/watch?v=pQzaHPoNX1I\"]",
+  "lastPullInfo": null,
+  "lastPushInfo": null,
+  "lastProcess": null,
+  "eventType": null,
+  "createdAt": "2018-06-21T14:33:36.000Z",
+  "updatedAt": "2018-06-21T14:33:36.000Z"
+}
+```
+
+## Retrieve a live event
+Retrieves the details of an existing event.
+You need only provide the unique identifier of event that was returned upon Live event creation.
+
+See details [here](https://docs.uiza.io/#retrieve-a-live-event).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  live = Uiza::Live.retrieve "your-live-id"
+  puts live.id
+  puts live.name
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "8b83886e-9cc3-4eab-9258-ebb16c0c73de",
+  "name": "checking 01",
+  "description": "checking",
+  "mode": "pull",
+  "resourceMode": "single",
+  "encode": 0,
+  "channelName": "checking-01",
+  "lastPresetId": null,
+  "lastFeedId": null,
+  "poster": "https://example.com/poster.jpeg",
+  "thumbnail": "https://example.com/thumbnail.jpeg",
+  "linkPublishSocial": null,
+  "linkStream": "[\"https://www.youtube.com/watch?v=pQzaHPoNX1I\"]",
+  "lastPullInfo": null,
+  "lastPushInfo": null,
+  "lastProcess": null,
+  "eventType": null,
+  "createdAt": "2018-06-21T14:33:36.000Z",
+  "updatedAt": "2018-06-21T14:33:36.000Z"
+}
+```

--- a/lib/uiza.rb
+++ b/lib/uiza.rb
@@ -26,6 +26,7 @@ require "uiza/api_operation/remove"
 require "uiza/entity"
 require "uiza/storage"
 require "uiza/category"
+require "uiza/live"
 
 module Uiza
   class << self

--- a/lib/uiza/live.rb
+++ b/lib/uiza/live.rb
@@ -1,0 +1,12 @@
+module Uiza
+  class Live
+    extend Uiza::APIOperation::Create
+    extend Uiza::APIOperation::Retrieve
+
+    OBJECT_API_PATH = "live/entity".freeze
+    OBJECT_API_DESCRIPTION_LINK = {
+      create: "https://docs.uiza.io/#create-a-live-event",
+      retrieve: "https://docs.uiza.io/#retrieve-a-live-event"
+    }.freeze
+  end
+end

--- a/spec/uiza/live/create_spec.rb
+++ b/spec/uiza/live/create_spec.rb
@@ -1,0 +1,160 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Live do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::create" do
+    context "API returns code 200" do
+      it "should returns an live" do
+        params = {
+          name: "test event",
+          mode: "push",
+          encode: 1,
+          dvr: 1,
+          linkStream: ["https://www.youtube.com/watch?v=GYktOE77oog"],
+          resourceMode: "single"
+        }
+
+        # create live
+        expected_method_1 = :post
+        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+        expected_headers_1 = {"Authorization" => "your-authorization"}
+        expected_body_1 = params
+        mock_response_1 = {
+          data: {
+            id: "your-live-id"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+          .to_return(body: mock_response_1.to_json)
+
+        # retrieve live with id = "your-live-id"
+        expected_method_2 = :get
+        expected_url_2 = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+        expected_headers_2 = {"Authorization" => "your-authorization"}
+        expected_query_2 = {id: "your-live-id"}
+        mock_response_2 = {
+          data: {
+            id: "your-live-id",
+            name: "test event",
+            mode: "push",
+            encode: 1,
+            dvr: 1,
+            linkStream: ["https://www.youtube.com/watch?v=GYktOE77oog"],
+            resourceMode: "single"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_2, expected_url_2)
+          .with(headers: expected_headers_2, query: expected_query_2)
+          .to_return(body: mock_response_2.to_json)
+
+        live = Uiza::Live.create params
+
+        expect(live.id).to eq "your-live-id"
+        expect(live.name).to eq "test event"
+        expect(live.mode).to eq "push"
+        expect(live.encode).to eq 1
+        expect(live.dvr).to eq 1
+        expect(live.linkStream).to eq ["https://www.youtube.com/watch?v=GYktOE77oog"]
+        expect(live.resourceMode).to eq "single"
+
+        expect(WebMock).to have_requested(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+
+        expect(WebMock).to have_requested(expected_method_2, expected_url_2)
+          .with(headers: expected_headers_2, query: expected_query_2)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 500, Uiza::Error::InternalServerError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      params = {
+        key: "invalid-value"
+      }
+
+      expected_method = :post
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_body = params
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::Live.create params}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#create-a-live-event"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+    end
+  end
+end

--- a/spec/uiza/live/retrieve_spec.rb
+++ b/spec/uiza/live/retrieve_spec.rb
@@ -1,0 +1,131 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Live do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::retrieve" do
+    context "API returns code 200" do
+      it "should returns an live" do
+        id = "your-live-id"
+
+        expected_method = :get
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+        expected_headers = {"Authorization" => "your-authorization"}
+        expected_query = {id: id}
+        mock_response = {
+          data: {
+            id: "your-live-id",
+            name: "test event",
+            mode: "push",
+            encode: 1,
+            dvr: 1,
+            linkStream: ["https://www.youtube.com/watch?v=GYktOE77oog"],
+            resourceMode: "single"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method, expected_url)
+          .with(headers: expected_headers, query: expected_query)
+          .to_return(body: mock_response.to_json)
+
+        live = Uiza::Live.retrieve id
+
+        expect(live.id).to eq "your-live-id"
+        expect(live.name).to eq "test event"
+        expect(live.mode).to eq "push"
+        expect(live.encode).to eq 1
+        expect(live.dvr).to eq 1
+        expect(live.linkStream).to eq ["https://www.youtube.com/watch?v=GYktOE77oog"]
+        expect(live.resourceMode).to eq "single"
+
+        expect(WebMock).to have_requested(expected_method, expected_url)
+          .with(headers: expected_headers, query: expected_query)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      id = "invalid-live-id"
+
+      expected_method = :get
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_query = {id: id}
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, query: expected_query)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::Live.retrieve id}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#retrieve-a-live-event"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, query: expected_query)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

- [#224309](https://dev.framgia.com/issues/224309)
- [#224311](https://dev.framgia.com/issues/224311)

## What's this PR do ?

- create and retrieve live streaming event
- rspec
- doc

## Library
*(List gem, library third party add new include version)*

- N/A
## Impacted Areas in Application
*(List features, api, models or services that this PR will affect)*

- N/A

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
*(List rake task command, environment variable need config after deploy)*

N/A

## Notes
```
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

params = {
  name: "test event",
  mode: "push",
  encode: 1,
  dvr: 1,
  linkStream: ["https://www.youtube.com/watch?v=GYktOE77oog"],
  resourceMode: "single"
}
response = Uiza::Live.create params
live = Uiza::Live.retrieve "your-live-id"
response.id
response.name
```
