### PR TITLE
224314_live_update

### DIFF
--- a/doc/LIVE_STREAMING.md
+++ b/doc/LIVE_STREAMING.md
@@ -119,3 +119,61 @@ Example Response
   "updatedAt": "2018-06-21T14:33:36.000Z"
 }
 ```
+
+## Update a live event
+Update the specific Live event by edit values of parameters.
+
+See details [here](https://docs.uiza.io/#update-a-live-event).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+params = {
+  id: "your-live-id",
+  name: "live test",
+  mode: "pull",
+  encode: 0,
+  dvr: 1
+  resourceMode: "single"
+}
+
+begin
+  live = Uiza::Live.update params
+  puts live.id
+  puts live.name
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "8b83886e-9cc3-4eab-9258-ebb16c0c73de",
+  "name": "checking 01",
+  "description": "checking",
+  "mode": "pull",
+  "resourceMode": "single",
+  "encode": 0,
+  "channelName": "checking-01",
+  "lastPresetId": null,
+  "lastFeedId": null,
+  "poster": "https://example.com/poster.jpeg",
+  "thumbnail": "https://example.com/thumbnail.jpeg",
+  "linkPublishSocial": null,
+  "linkStream": "[\"https://www.youtube.com/watch?v=pQzaHPoNX1I\"]",
+  "lastPullInfo": null,
+  "lastPushInfo": null,
+  "lastProcess": null,
+  "eventType": null,
+  "createdAt": "2018-06-21T14:33:36.000Z",
+  "updatedAt": "2018-06-21T14:33:36.000Z"
+}
+```

--- a/lib/uiza/live.rb
+++ b/lib/uiza/live.rb
@@ -2,11 +2,13 @@ module Uiza
   class Live
     extend Uiza::APIOperation::Create
     extend Uiza::APIOperation::Retrieve
+    extend Uiza::APIOperation::Update
 
     OBJECT_API_PATH = "live/entity".freeze
     OBJECT_API_DESCRIPTION_LINK = {
       create: "https://docs.uiza.io/#create-a-live-event",
-      retrieve: "https://docs.uiza.io/#retrieve-a-live-event"
+      retrieve: "https://docs.uiza.io/#retrieve-a-live-event",
+      update: "https://docs.uiza.io/#update-a-live-event"
     }.freeze
   end
 end

--- a/spec/uiza/live/update_spec.rb
+++ b/spec/uiza/live/update_spec.rb
@@ -1,0 +1,160 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Live do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::update" do
+    context "API returns code 200" do
+      it "should returns an live" do
+        params = {
+          id: "your-live-id",
+          name: "live test",
+          mode: "push",
+          encode: 0,
+          dvr: 1,
+          resourceMode: "single"
+        }
+
+        # update live
+        expected_method_1 = :put
+        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+        expected_headers_1 = {"Authorization" => "your-authorization"}
+        expected_body_1 = params
+        mock_response_1 = {
+          data: {
+            id: "your-live-id"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+          .to_return(body: mock_response_1.to_json)
+
+        # retrieve live with id = "your-live-id"
+        expected_method_2 = :get
+        expected_url_2 = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+        expected_headers_2 = {"Authorization" => "your-authorization"}
+        expected_query_2 = {id: "your-live-id"}
+        mock_response_2 = {
+          data: {
+            id: "your-live-id",
+            name: "live test",
+            mode: "push",
+            encode: 0,
+            dvr: 1,
+            linkStream: ["https://www.youtube.com/watch?v=GYktOE77oog"],
+            resourceMode: "single"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_2, expected_url_2)
+          .with(headers: expected_headers_2, query: expected_query_2)
+          .to_return(body: mock_response_2.to_json)
+
+        live = Uiza::Live.update params
+
+        expect(live.id).to eq "your-live-id"
+        expect(live.name).to eq "live test"
+        expect(live.mode).to eq "push"
+        expect(live.encode).to eq 0
+        expect(live.dvr).to eq 1
+        expect(live.linkStream).to eq ["https://www.youtube.com/watch?v=GYktOE77oog"]
+        expect(live.resourceMode).to eq "single"
+
+        expect(WebMock).to have_requested(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+
+        expect(WebMock).to have_requested(expected_method_2, expected_url_2)
+          .with(headers: expected_headers_2, query: expected_query_2)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 500, Uiza::Error::InternalServerError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      params = {
+        key: "invalid-value"
+      }
+
+      expected_method = :put
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_body = params
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::Live.update params}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#update-a-live-event"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

* [#224314](https://dev.framgia.com/issues/224314)

## What's this PR do ?

- [x] update live streaming event
- [x] rspec
- [x] doc

## Library

- N/A

## Impacted Areas in Application

- N/A

## Performance

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
- N/A

## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

params = {
  id: "your-live-id"
  name: "test event",
  mode: "push",
  encode: 1,
  dvr: 1,
  linkStream: ["https://www.youtube.com/watch?v=GYktOE77oog"],
  resourceMode: "single"
}
response = Uiza::Live.update params
live = Uiza::Live.retrieve "your-live-id"
response.id
response.name
```