### PR TITLE
224321_live_delete

### DIFF
--- a/doc/LIVE_STREAMING.md
+++ b/doc/LIVE_STREAMING.md
@@ -330,3 +330,33 @@ Example Response
   "day": 1533271205999
 }
 ```
+
+## Delete a record file
+Delete a recorded file
+
+See details [here](https://docs.uiza.io/#delete-a-record-file).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  live = Uiza::Live.delete "your-record-id" #Identifier of record (get from list record)
+  puts live.id
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "040df935-61c4-46f7-a41f-0a899ebaa2cc"
+}
+```

--- a/lib/uiza/live.rb
+++ b/lib/uiza/live.rb
@@ -11,7 +11,8 @@ module Uiza
       update: "https://docs.uiza.io/#update-a-live-event",
       start_feed: "https://docs.uiza.io/#start-a-live-feed",
       list_recorded: "https://docs.uiza.io/#list-all-recorded-files",
-      get_view: "https://docs.uiza.io/#get-view-of-live-feed"
+      get_view: "https://docs.uiza.io/#get-view-of-live-feed",
+      delete: "https://docs.uiza.io/#delete-a-record-file"
     }.freeze
 
     class << self
@@ -44,6 +45,16 @@ module Uiza
         description_link = OBJECT_API_DESCRIPTION_LINK[:get_view]
 
         uiza_client = UizaClient.new url, method, headers, params, description_link
+        uiza_client.execute_request
+      end
+
+      def delete id
+        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/dvr"
+        method = :delete
+        headers = {"Authorization" => Uiza.authorization}
+        params = {id: id}
+
+        uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:delete]
         uiza_client.execute_request
       end
     end

--- a/spec/uiza/live/delete_spec.rb
+++ b/spec/uiza/live/delete_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Live do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::delete" do
+    context "API returns code 200" do
+      it "should returns an id" do
+        id = "your-record-id"
+
+        expected_method = :delete
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity/dvr"
+        expected_headers = {"Authorization" => "your-authorization"}
+        expected_body = {id: id}
+        mock_response = {
+          data: {
+            id: "your-record-id"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method, expected_url)
+          .with(headers: expected_headers, body: expected_body)
+          .to_return(body: mock_response.to_json)
+
+        response = Uiza::Live.delete id
+
+        expect(response.id).to eq "your-record-id"
+
+        expect(WebMock).to have_requested(expected_method, expected_url)
+          .with(headers: expected_headers, body: expected_body)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      id = "invalid-record-id"
+
+      expected_method = :delete
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity/dvr"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_body = {id: id}
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::Live.delete id}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#delete-a-record-file"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

- [#224321](https://dev.framgia.com/issues/224321)

## What's this PR do ?

- [x] Delete a record file
- [x] rspec - Delete a record file
- [x] doc - Delete a record file
## Library
N/A

## Impacted Areas in Application
N/A

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [ ] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A
## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

response = Uiza::Live.delete "your-record-id"
response.id
```
