### PR TITLE
224318_live_stop_feed

### DIFF
--- a/doc/LIVE_STREAMING.md
+++ b/doc/LIVE_STREAMING.md
@@ -237,6 +237,61 @@ Example Response
 }
 ```
 
+## Stop a live feed
+Stop live event
+
+See details [here](https://docs.uiza.io/#stop-a-live-feed).
+
+```ruby
+require "uiza"
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+params = {
+  id: "your-live-id",
+  name: "live test",
+  mode: "pull",
+  encode: 0,
+  dvr: 1
+  resourceMode: "single"
+}
+begin
+  live = Uiza::Live.stop_feed "your-live-id"
+  puts live.id
+  puts live.name
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "8b83886e-9cc3-4eab-9258-ebb16c0c73de",
+  "name": "checking 01",
+  "description": "checking",
+  "mode": "pull",
+  "resourceMode": "single",
+  "encode": 0,
+  "channelName": "checking-01",
+  "lastPresetId": null,
+  "lastFeedId": null,
+  "poster": "https://example.com/poster.jpeg",
+  "thumbnail": "https://example.com/thumbnail.jpeg",
+  "linkPublishSocial": null,
+  "linkStream": "[\"https://www.youtube.com/watch?v=pQzaHPoNX1I\"]",
+  "lastPullInfo": null,
+  "lastPushInfo": null,
+  "lastProcess": null,
+  "eventType": null,
+  "createdAt": "2018-06-21T14:33:36.000Z",
+  "updatedAt": "2018-06-21T14:33:36.000Z"
+}
+```
+
 ## List all recorded files
 Retrieves list of recorded file after streamed (only available when your live event has turned on Record feature)
 

--- a/lib/uiza/live.rb
+++ b/lib/uiza/live.rb
@@ -11,6 +11,7 @@ module Uiza
       update: "https://docs.uiza.io/#update-a-live-event",
       start_feed: "https://docs.uiza.io/#start-a-live-feed",
       list_recorded: "https://docs.uiza.io/#list-all-recorded-files",
+      stop_feed: "https://docs.uiza.io/#stop-a-live-feed",
       get_view: "https://docs.uiza.io/#get-view-of-live-feed",
       delete: "https://docs.uiza.io/#delete-a-record-file"
     }.freeze
@@ -23,6 +24,18 @@ module Uiza
         params = {id: id}
 
         uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:start_feed]
+        response = uiza_client.execute_request
+
+        retrieve response.id
+      end
+
+      def stop_feed id
+        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/feed"
+        method = :put
+        headers = {"Authorization" => Uiza.authorization}
+        params = {id: id}
+
+        uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:stop_feed]
         response = uiza_client.execute_request
 
         retrieve response.id

--- a/spec/uiza/live/stop_feed_spec.rb
+++ b/spec/uiza/live/stop_feed_spec.rb
@@ -1,0 +1,151 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Live do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::stop_feed" do
+    context "API returns code 200" do
+      it "should returns a live" do
+        id = "your-live-id"
+
+        # stop a live feed
+        expected_method_1 = :put
+        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity/feed"
+        expected_headers_1 = {"Authorization" => "your-authorization"}
+        expected_body_1 = {id: id}
+        mock_response_1 = {
+          data: {
+            id: "your-live-id"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+          .to_return(body: mock_response_1.to_json)
+
+        # retrieve live with id = "your-live-id"
+        expected_method_2 = :get
+        expected_url_2 = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+        expected_headers_2 = {"Authorization" => "your-authorization"}
+        expected_query_2 = {id: "your-live-id"}
+        mock_response_2 = {
+          data: {
+            id: "your-live-id",
+            name: "test event",
+            mode: "push",
+            encode: 1,
+            dvr: 1,
+            linkStream: ["https://www.youtube.com/watch?v=GYktOE77oog"],
+            resourceMode: "single"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_2, expected_url_2)
+          .with(headers: expected_headers_2, query: expected_query_2)
+          .to_return(body: mock_response_2.to_json)
+
+        live = Uiza::Live.stop_feed id
+
+        expect(live.id).to eq "your-live-id"
+        expect(live.name).to eq "test event"
+        expect(live.mode).to eq "push"
+        expect(live.encode).to eq 1
+        expect(live.dvr).to eq 1
+        expect(live.linkStream).to eq ["https://www.youtube.com/watch?v=GYktOE77oog"]
+        expect(live.resourceMode).to eq "single"
+
+        expect(WebMock).to have_requested(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+
+        expect(WebMock).to have_requested(expected_method_2, expected_url_2)
+          .with(headers: expected_headers_2, query: expected_query_2)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 500, Uiza::Error::InternalServerError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      id = "invalid-value"
+
+      expected_method = :put
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity/feed"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_body = {id: id}
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::Live.stop_feed id}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#stop-a-live-feed"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

* [#224317](https://dev.framgia.com/issues/224317)

## What's this PR do ?

- [x] stop live feed
- [x] rspec
- [x] doc

## Library

- N/A

## Impacted Areas in Application

- N/A

## Performance

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
- N/A

## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

response = Uiza::Live.stop_feed "your-live-id"
response.id
response.name
```