### PR TITLE
224856_callback_retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,25 @@ Callback used to retrieve an information for Uiza to your server, so you can hav
 
 See details [here](https://github.com/uizaio/api-wrapper-ruby/blob/develop/doc/CALLBACK.md).
 
+```ruby
+require "json"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  callback = Uiza::Live.retrieve "your-callback-id"
+  puts callback.id
+  puts callback.url
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
 ## Analytic
 Monitor the four key dimensions of video QoS: playback failures, startup time, rebuffering, and video quality.
 These 15 metrics help you track playback performance, so your team can know exactly what’s going on.

--- a/doc/CALLBACK.md
+++ b/doc/CALLBACK.md
@@ -2,3 +2,43 @@
 Callback used to retrieve an information for Uiza to your server, so you can have a trigger notice about an entity is upload completed and .
 
 See details [here](https://docs.uiza.io/#callback).
+
+## Retrieve a callback
+Retrieves the details of an existing callback.
+
+See details [here](https://docs.uiza.io/#retrieve-a-callback).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  callback = Uiza::Category.retrieve "your-callback-id"
+  puts callback.id
+  puts callback.url
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "0a6bf245-1cce-494f-a193-b5a44aa05558",
+  "url": "https://callback-url.uiza.co",
+  "headersData": null,
+  "jsonData": {
+    "text": "example callback"
+  },
+  "method": "POST",
+  "status": 1,
+  "createdAt": "2018-06-23T01:27:08.000Z",
+  "updatedAt": "2018-06-23T01:27:08.000Z"
+}
+```

--- a/lib/uiza.rb
+++ b/lib/uiza.rb
@@ -27,6 +27,7 @@ require "uiza/entity"
 require "uiza/storage"
 require "uiza/category"
 require "uiza/live"
+require "uiza/callback"
 
 module Uiza
   class << self

--- a/lib/uiza/callback.rb
+++ b/lib/uiza/callback.rb
@@ -1,0 +1,10 @@
+module Uiza
+  class Callback
+    extend Uiza::APIOperation::Retrieve
+
+    OBJECT_API_PATH = "media/entity/callback".freeze
+    OBJECT_API_DESCRIPTION_LINK = {
+      retrieve: "https://docs.uiza.io/#retrieve-a-callback"
+    }.freeze
+  end
+end

--- a/spec/uiza/callback/retrieve_spec.rb
+++ b/spec/uiza/callback/retrieve_spec.rb
@@ -1,0 +1,121 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Callback do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::retrieve" do
+    context "API returns code 200" do
+      it "should returns a callback" do
+        id = "your-callback-id"
+
+        expected_method = :get
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+        expected_headers = {"Authorization" => "your-authorization"}
+        expected_query = {id: id}
+        mock_response = {
+          data: {
+            id: "your-callback-id",
+            url: "https://callback-url.uiza.co"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method, expected_url)
+          .with(headers: expected_headers, query: expected_query)
+          .to_return(body: mock_response.to_json)
+
+        callback = Uiza::Callback.retrieve id
+
+        expect(callback.id).to eq "your-callback-id"
+        expect(callback.url).to eq "https://callback-url.uiza.co"
+
+        expect(WebMock).to have_requested(expected_method, expected_url)
+          .with(headers: expected_headers, query: expected_query)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      id = "invalid-callback-id"
+
+      expected_method = :get
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_query = {id: id}
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, query: expected_query)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::Callback.retrieve id}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#retrieve-a-callback"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, query: expected_query)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

- [#224856](https://dev.framgia.com/issues/224856)

## What's this PR do ?

- [x] retrieve a callback
- [x] rspec - retrieve a callback
- [x] doc - retrieve a callback
## Library
N/A
## Impacted Areas in Application
N/A

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [ ] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A

## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

response = Uiza::Live.retrieve "your-callback-id"
response.id
response.url
```
