### PR TITLE
224854_callback_create

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "rubocop"
-gem "webmock"
 gem "simplecov"
+gem "webmock"
 
 gemspec

--- a/doc/CALLBACK.md
+++ b/doc/CALLBACK.md
@@ -3,6 +3,49 @@ Callback used to retrieve an information for Uiza to your server, so you can hav
 
 See details [here](https://docs.uiza.io/#callback).
 
+## Create a callback
+This API will allow you setup a callback to your server when an entity is completed for upload or public
+
+See details [here](https://docs.uiza.io/#create-a-callback).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+params = {
+  url: "https://callback-url.uiza.co",
+  method: "POST"
+}
+
+begin
+  callback = Uiza::Callback.create params
+  puts callback.id
+  puts callback.url
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "0a6bf245-1cce-494f-a193-b5a44aa05558",
+  "url": "https://callback-url.uiza.co",
+  "headersData": null,
+  "jsonData": null,
+  "method": "POST",
+  "status": 1,
+  "createdAt": "2018-06-23T01:27:08.000Z",
+  "updatedAt": "2018-06-23T01:27:08.000Z"
+}
+```
+
 ## Retrieve a callback
 Retrieves the details of an existing callback.
 

--- a/lib/uiza/callback.rb
+++ b/lib/uiza/callback.rb
@@ -1,9 +1,11 @@
 module Uiza
   class Callback
+    extend Uiza::APIOperation::Create
     extend Uiza::APIOperation::Retrieve
 
     OBJECT_API_PATH = "media/entity/callback".freeze
     OBJECT_API_DESCRIPTION_LINK = {
+      create: "https://docs.uiza.io/#create-a-callback",
       retrieve: "https://docs.uiza.io/#retrieve-a-callback"
     }.freeze
   end

--- a/lib/uiza/uiza_open_struct.rb
+++ b/lib/uiza/uiza_open_struct.rb
@@ -1,13 +1,14 @@
 module Uiza
   class UizaOpenStruct < OpenStruct
-    def define_methods()
+    def define_methods
       data = to_h
       data.each do |key, value|
         if value.is_a?(Uiza::UizaOpenStruct)
-          value.define_methods()
+          value.define_methods
         else
-          self.define_singleton_method(key) do |*args|
+          define_singleton_method(key) do |*args|
             return super(*args) if args.any?
+
             value
           end
         end

--- a/spec/uiza/callback/create_spec.rb
+++ b/spec/uiza/callback/create_spec.rb
@@ -1,0 +1,148 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Callback do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::create" do
+    context "API returns code 200" do
+      it "should returns a callback" do
+        params = {
+          url: "https://callback-url.uiza.co",
+          method: "POST"
+        }
+
+        # create callback
+        expected_method_1 = :post
+        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+        expected_headers_1 = {"Authorization" => "your-authorization"}
+        expected_body_1 = params
+        mock_response_1 = {
+          data: {
+            id: "your-callback-id",
+            url: "https://callback-url.uiza.co",
+            method: "POST"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+          .to_return(body: mock_response_1.to_json)
+
+        # retrieve callback with id = "your-callback-id"
+        expected_method_2 = :get
+        expected_url_2 = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+        expected_headers_2 = {"Authorization" => "your-authorization"}
+        expected_query_2 = {id: "your-callback-id"}
+        mock_response_2 = {
+          data: {
+            id: "your-callback-id",
+            url: "https://callback-url.uiza.co"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_2, expected_url_2)
+          .with(headers: expected_headers_2, query: expected_query_2)
+          .to_return(body: mock_response_2.to_json)
+
+        callback = Uiza::Callback.create params
+
+        expect(callback.id).to eq "your-callback-id"
+        expect(callback.url).to eq "https://callback-url.uiza.co"
+
+        expect(WebMock).to have_requested(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+
+        expect(WebMock).to have_requested(expected_method_2, expected_url_2)
+          .with(headers: expected_headers_2, query: expected_query_2)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 500, Uiza::Error::InternalServerError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      params = {
+        key: "invalid-value"
+      }
+
+      expected_method = :post
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_body = params
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::Callback.create params}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#create-a-callback"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

- [#224854](https://dev.framgia.com/issues/224854)

## What's this PR do ?

- [x] create a callback
- [x] rspec - create a callback
- [x] doc - create a callback
- [x] fix rubocop
## Library
N/A

## Impacted Areas in Application
N/A
## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [ ] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A

## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

params = {
  url: "https://callback-url.uiza.co", 
  method: "POST"
}
response = Uiza::Callback.create params
response.id
response.url
```
