### PR TITLE
224858_callback_delete

### DIFF
--- a/doc/CALLBACK.md
+++ b/doc/CALLBACK.md
@@ -129,3 +129,33 @@ Example Response
   "updatedAt": "2018-06-23T01:27:08.000Z"
 }
 ```
+
+## Delete a callback
+Delete an existing callback.
+
+See details [here](https://docs.uiza.io/#delete-a-callback).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  callback = Uiza::Callback.delete "your-callback-id"
+  puts callback.id
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "your-callback-id"
+}
+```

--- a/lib/uiza/callback.rb
+++ b/lib/uiza/callback.rb
@@ -3,12 +3,14 @@ module Uiza
     extend Uiza::APIOperation::Create
     extend Uiza::APIOperation::Retrieve
     extend Uiza::APIOperation::Update
+    extend Uiza::APIOperation::Delete
 
     OBJECT_API_PATH = "media/entity/callback".freeze
     OBJECT_API_DESCRIPTION_LINK = {
       create: "https://docs.uiza.io/#create-a-callback",
       retrieve: "https://docs.uiza.io/#retrieve-a-callback",
-      update: "https://docs.uiza.io/#update-a-callback"
+      update: "https://docs.uiza.io/#update-a-callback",
+      delete: "https://docs.uiza.io/#delete-a-callback"
     }.freeze
   end
 end

--- a/spec/uiza/callback/delete_spec.rb
+++ b/spec/uiza/callback/delete_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Callback do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::delete" do
+    context "API returns code 200" do
+      it "should returns an id" do
+        id = "your-callback-id"
+
+        expected_method = :delete
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+        expected_headers = {"Authorization" => "your-authorization"}
+        expected_body = {id: id}
+        mock_response = {
+          data: {
+            id: "your-callback-id"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method, expected_url)
+          .with(headers: expected_headers, body: expected_body)
+          .to_return(body: mock_response.to_json)
+
+        response = Uiza::Callback.delete id
+
+        expect(response.id).to eq "your-callback-id"
+
+        expect(WebMock).to have_requested(expected_method, expected_url)
+          .with(headers: expected_headers, body: expected_body)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      id = "invalid-callback-id"
+
+      expected_method = :delete
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_body = {id: id}
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::Callback.delete id}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#delete-a-callback"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

- [#224858](https://dev.framgia.com/issues/224858)

## What's this PR do ?

- [x] delete a callback
- [x] rspec - delete a callback
- [x] doc - delete a callback

## Library
N/A

## Impacted Areas in Application
N/A

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [ ] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A

## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

response = Uiza::Callback.delete "you-callback-id"
response.id
```
