### PR TITLE
225750_user_retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,32 @@ rescue StandardError => e
 end
 ```
 
+## User Management
+You can manage user with APIs user. Uiza have 2 levels of user:
+  Admin - This account will have the highest priority, can have permission to create & manage users.
+  User - This account level is under Admin level. It only manages APIs that relates to this account.
+
+See details [here](https://docs.uiza.io/#user-management).
+
+```ruby
+require "json"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  user = Uiza::User.retrieve "your-user-id"
+  puts user.id
+  puts user.username
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
 ## Analytic
 Monitor the four key dimensions of video QoS: playback failures, startup time, rebuffering, and video quality.
 These 15 metrics help you track playback performance, so your team can know exactly what’s going on.

--- a/doc/USER.md
+++ b/doc/USER.md
@@ -1,0 +1,45 @@
+## User Management
+You can manage user with APIs user. Uiza have 2 levels of user:
+  Admin - This account will have the highest priority, can have permission to create & manage users.
+  User - This account level is under Admin level. It only manages APIs that relates to this account.
+
+See details [here](https://docs.uiza.io/#user-management).
+
+## Retrieve an user
+Retrieves the details of an existing user.
+You need only supply the unique userId that was returned upon user creation.
+
+See details [here](https://docs.uiza.io/#retrieve-an-user).
+
+```ruby
+require "json"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  user = Uiza::User.retrieve "your-user-id"
+  puts user.id
+  puts user.username
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "id": "37d6706e-be91-463e-b3b3-b69451dd4752",
+  "isAdmin": 0,
+  "username": "user_test",
+  "email": "user_test@uiza.io",
+  "avatar": "https://exemple.com/avatar.jpeg",
+  "fullname": "User Test",
+  "updatedAt": "2018-06-22T18:05:47.000Z",
+  "createdAt": "2018-06-22T18:05:47.000Z"
+}
+```

--- a/lib/uiza.rb
+++ b/lib/uiza.rb
@@ -29,6 +29,7 @@ require "uiza/storage"
 require "uiza/category"
 require "uiza/live"
 require "uiza/callback"
+require "uiza/user"
 
 module Uiza
   class << self

--- a/lib/uiza/user.rb
+++ b/lib/uiza/user.rb
@@ -1,0 +1,10 @@
+module Uiza
+  class User
+    extend Uiza::APIOperation::Retrieve
+
+    OBJECT_API_PATH = "admin/user".freeze
+    OBJECT_API_DESCRIPTION_LINK = {
+      retrieve: "https://docs.uiza.io/#retrieve-an-user"
+    }.freeze
+  end
+end

--- a/spec/uiza/user/retrieve_spec.rb
+++ b/spec/uiza/user/retrieve_spec.rb
@@ -1,0 +1,125 @@
+require "spec_helper"
+
+RSpec.describe Uiza::User do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::retrieve" do
+    context "API returns code 200" do
+      it "should returns an user" do
+        id = "your-user-id"
+
+        expected_method = :get
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user"
+        expected_headers = {"Authorization" => "your-authorization"}
+        expected_query = {id: id}
+        mock_response = {
+          data: {
+            id: "your-user-id",
+            isAdmin: 1,
+            username: "user_test",
+            email: "user_test@uiza.io"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method, expected_url)
+          .with(headers: expected_headers, query: expected_query)
+          .to_return(body: mock_response.to_json)
+
+        user = Uiza::User.retrieve id
+
+        expect(user.id).to eq "your-user-id"
+        expect(user.isAdmin).to eq 1
+        expect(user.username).to eq "user_test"
+        expect(user.email).to eq "user_test@uiza.io"
+
+        expect(WebMock).to have_requested(expected_method, expected_url)
+          .with(headers: expected_headers, query: expected_query)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      id = "invalid-user-id"
+
+      expected_method = :get
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_query = {id: id}
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, query: expected_query)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::User.retrieve id}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#retrieve-an-user"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, query: expected_query)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

- [#225750](https://dev.framgia.com/issues/225750)

## What's this PR do ?

- [x] retrieve an user
- [x] doc - retrieve an user
- [x] rspec - retrieve an user

## Library
N/A

## Impacted Areas in Application
N/A

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [x] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A
## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

response = Uiza::User.retrieve "your-user-id"
response.id
```