### PR TITLE
225765_Analytic_get_total_line

### DIFF
--- a/doc/ANALYTIC.md
+++ b/doc/ANALYTIC.md
@@ -3,3 +3,44 @@ Monitor the four key dimensions of video QoS: playback failures, startup time, r
 These 15 metrics help you track playback performance, so your team can know exactly what’s going on.
 
 See details [here](https://docs.uiza.io/#analytic).
+
+## Total Line
+Get data grouped by hour (data refresh every 5 minutes). Track video playback on any metric performance, so you can know exactly what’s happening on every user’s device and debug more effectively.
+
+See details [here](https://docs.uiza.io/#total-line).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+params = {
+  start_date: "YYYY-MM-DD hh:mm",
+  end_date: "YYYY-MM-DD hh:mm",
+  metric: "rebuffer_count"
+}
+
+begin
+  response = Uiza::Analytic.get_total_line params
+  puts response.first.rebuffer_count
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+ "date_time": 1542978000000,
+ "rebuffer_count": 1.6666666666666667
+},
+{
+ "date_time": 1543215600000,
+ "rebuffer_count": 5
+}
+```

--- a/lib/uiza.rb
+++ b/lib/uiza.rb
@@ -30,6 +30,7 @@ require "uiza/category"
 require "uiza/live"
 require "uiza/callback"
 require "uiza/user"
+require "uiza/analytic"
 
 module Uiza
   class << self

--- a/lib/uiza/analytic.rb
+++ b/lib/uiza/analytic.rb
@@ -1,0 +1,20 @@
+module Uiza
+  class Analytic
+    OBJECT_API_PATH = "analytic/entity/video-quality".freeze
+    OBJECT_API_DESCRIPTION_LINK = {
+      get_total_line: "https://docs.uiza.io/#total-line"
+    }.freeze
+
+    class << self
+      def get_total_line params
+        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/total-line-v2"
+        method = :get
+        headers = {"Authorization" => Uiza.authorization}
+        description_link = OBJECT_API_DESCRIPTION_LINK[:get_total_line]
+
+        uiza_client = UizaClient.new url, method, headers, params, description_link
+        uiza_client.execute_request
+      end
+    end
+  end
+end

--- a/spec/uiza/analytic/get_total_line_spec.rb
+++ b/spec/uiza/analytic/get_total_line_spec.rb
@@ -1,48 +1,49 @@
 require "spec_helper"
 
-RSpec.describe Uiza::Category do
+RSpec.describe Uiza::Analytic do
   before(:each) do
     Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
     Uiza.authorization = "your-authorization"
   end
 
-  describe "::create_relation" do
+  describe "::get_total_line" do
     context "API returns code 200" do
-      it "should returns an array of relation" do
+      it "should returns an array of analytic metrics" do
         params = {
-          entityId: "your-entity-id-01",
-          metadataIds: ["your-category-id-01", "your-category-id-02"]
+          start_date: "YYYY-MM-DD hh:mm",
+          end_date: "YYYY-MM-DD hh:mm",
+          metric: "analytic_metric"
         }
 
-        expected_method = :post
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/related/metadata"
+        expected_method = :get
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/analytic/entity/video-quality/total-line-v2"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_body = params
+        expected_query = params
         mock_response = {
           data: [{
-            entityId: "your-entity-id-01",
-            metadataId: "your-category-id-01"
+            date_time: "time-point-01",
+            analytic_metric: "analytic-metric-value-01"
           }, {
-            entityId: "your-entity-id-01",
-            metadataId: "your-category-id-02"
+            date_time: "time-point-02",
+            analytic_metric: "analytic-metric-value-02"
           }],
           code: 200
         }
 
         stub_request(expected_method, expected_url)
-          .with(headers: expected_headers, body: expected_body)
+          .with(headers: expected_headers, query: expected_query)
           .to_return(body: mock_response.to_json)
 
-        relations = Uiza::Category.create_relation params
+        metrics = Uiza::Analytic.get_total_line params
 
-        expect(relations).to be_a Array
-        expect(relations.first.entityId).to eq "your-entity-id-01"
-        expect(relations.first.metadataId).to eq "your-category-id-01"
-        expect(relations.last.entityId).to eq "your-entity-id-01"
-        expect(relations.last.metadataId).to eq "your-category-id-02"
+        expect(metrics).to be_a Array
+        expect(metrics.first.date_time).to eq "time-point-01"
+        expect(metrics.first.analytic_metric).to eq "analytic-metric-value-01"
+        expect(metrics.last.date_time).to eq "time-point-02"
+        expect(metrics.last.analytic_metric).to eq "analytic-metric-value-02"
 
         expect(WebMock).to have_requested(expected_method, expected_url)
-          .with(headers: expected_headers, body: expected_body)
+          .with(headers: expected_headers, query: expected_query)
       end
     end
 
@@ -103,31 +104,32 @@ RSpec.describe Uiza::Category do
 
   def api_return_error_code error_code, error_class
     params = {
-      entityId: "your-entity-id-01",
-      metadataIds: ["your-category-id-01", "your-category-id-02"]
+      start_date: "invalid-value",
+      end_date: "invalid-value",
+      metric: "invalid-value"
     }
 
-    expected_method = :post
-    expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/related/metadata"
+    expected_method = :get
+    expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/analytic/entity/video-quality/total-line-v2"
     expected_headers = {"Authorization" => "your-authorization"}
-    expected_body = params
+    expected_query = params
     mock_response = {
       code: error_code,
       message: "error message"
     }
 
     stub_request(expected_method, expected_url)
-      .with(headers: expected_headers, body: expected_body)
+      .with(headers: expected_headers, query: expected_query)
       .to_return(body: mock_response.to_json)
 
-    expect{Uiza::Category.create_relation params}.to raise_error do |error|
+    expect{Uiza::Analytic.get_total_line params}.to raise_error do |error|
       expect(error).to be_a error_class
-      expect(error.description_link).to eq "https://docs.uiza.io/#create-category-relation"
+      expect(error.description_link).to eq "https://docs.uiza.io/#total-line"
       expect(error.code).to eq error_code
       expect(error.message).to eq "error message"
     end
 
     expect(WebMock).to have_requested(expected_method, expected_url)
-      .with(headers: expected_headers, body: expected_body)
+      .with(headers: expected_headers, query: expected_query)
   end
 end

--- a/spec/uiza/category/delete_relation_spec.rb
+++ b/spec/uiza/category/delete_relation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Uiza::Category do
     Uiza.authorization = "your-authorization"
   end
 
-  describe "::list" do
+  describe "::delete_relation" do
     context "API returns code 200" do
       it "should returns an array of relation" do
         params = {

--- a/spec/uiza/live/create_spec.rb
+++ b/spec/uiza/live/create_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Uiza::Live do
 
   describe "::create" do
     context "API returns code 200" do
-      it "should returns an live" do
+      it "should returns a live" do
         params = {
           name: "test event",
           mode: "push",

--- a/spec/uiza/live/retrieve_spec.rb
+++ b/spec/uiza/live/retrieve_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Uiza::Live do
 
   describe "::retrieve" do
     context "API returns code 200" do
-      it "should returns an live" do
+      it "should returns a live" do
         id = "your-live-id"
 
         expected_method = :get

--- a/spec/uiza/live/update_spec.rb
+++ b/spec/uiza/live/update_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Uiza::Live do
 
   describe "::update" do
     context "API returns code 200" do
-      it "should returns an live" do
+      it "should returns a live" do
         params = {
           id: "your-live-id",
           name: "live test",


### PR DESCRIPTION
## Related Tickets

* [#225765](https://dev.framgia.com/issues/225765)

## What's this PR do ?

- [x] Analytic: get_type
- [x] spec
- [x] doc

## Library

- N/A

## Impacted Areas in Application

- N/A

## Performance

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
- N/A

## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

params = {
  start_date: "2019-01-01 00:00",
  end_date: "2019-02-01 00:00",
  metric: "rebuffer_count"
}
response = Uiza::Analytic.get_total_line params
response.first.rebuffer_count
```