### PR TITLE
225766_Analytic_get_type

### DIFF
--- a/doc/ANALYTIC.md
+++ b/doc/ANALYTIC.md
@@ -44,3 +44,48 @@ Example Response
  "rebuffer_count": 5
 }
 ```
+
+## Type
+Get data base on 4 type of filter: country, device, title, player
+
+See details [here](https://docs.uiza.io/#type).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+params = {
+  start_date: "YYYY-MM-DD hh:mm",
+  end_date: "YYYY-MM-DD hh:mm",
+  type_filter: "country"
+}
+
+begin
+  response = Uiza::Analytic.get_type params
+  puts response.first.name
+  puts response.first.total_view
+  puts response.first.percentage_of_view
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "name": "Vietnam",
+  "total_view": 15,
+  "percentage_of_view": 0.625
+},
+{
+  "name": "Other",
+  "total_view": 9,
+  "percentage_of_view": 0.375
+}
+```

--- a/lib/uiza/analytic.rb
+++ b/lib/uiza/analytic.rb
@@ -2,7 +2,8 @@ module Uiza
   class Analytic
     OBJECT_API_PATH = "analytic/entity/video-quality".freeze
     OBJECT_API_DESCRIPTION_LINK = {
-      get_total_line: "https://docs.uiza.io/#total-line"
+      get_total_line: "https://docs.uiza.io/#total-line",
+      get_type: "https://docs.uiza.io/#type"
     }.freeze
 
     class << self
@@ -11,6 +12,16 @@ module Uiza
         method = :get
         headers = {"Authorization" => Uiza.authorization}
         description_link = OBJECT_API_DESCRIPTION_LINK[:get_total_line]
+
+        uiza_client = UizaClient.new url, method, headers, params, description_link
+        uiza_client.execute_request
+      end
+
+      def get_type params
+        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/type"
+        method = :get
+        headers = {"Authorization" => Uiza.authorization}
+        description_link = OBJECT_API_DESCRIPTION_LINK[:get_type]
 
         uiza_client = UizaClient.new url, method, headers, params, description_link
         uiza_client.execute_request

--- a/spec/uiza/analytic/get_type_spec.rb
+++ b/spec/uiza/analytic/get_type_spec.rb
@@ -1,0 +1,137 @@
+require "spec_helper"
+
+RSpec.describe Uiza::Analytic do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::get_type" do
+    context "API returns code 200" do
+      it "should returns an array of filter" do
+        params = {
+          start_date: "YYYY-MM-DD hh:mm",
+          end_date: "YYYY-MM-DD hh:mm",
+          type_filter: "filter-type"
+        }
+
+        expected_method = :get
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/analytic/entity/video-quality/type"
+        expected_headers = {"Authorization" => "your-authorization"}
+        expected_query = params
+        mock_response = {
+          data: [{
+            name: "filter-01",
+            total_view: 15,
+            percentage_of_view: 0.625
+          }, {
+            name: "filter-02",
+            total_view: 17,
+            percentage_of_view: 0.625
+          }],
+          code: 200
+        }
+
+        stub_request(expected_method, expected_url)
+          .with(headers: expected_headers, query: expected_query)
+          .to_return(body: mock_response.to_json)
+
+        filters = Uiza::Analytic.get_type params
+
+        expect(filters).to be_a Array
+        expect(filters.first.name).to eq "filter-01"
+        expect(filters.first.total_view).to eq 15
+        expect(filters.last.name).to eq "filter-02"
+        expect(filters.last.total_view).to eq 17
+
+        expect(WebMock).to have_requested(expected_method, expected_url)
+          .with(headers: expected_headers, query: expected_query)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 500, Uiza::Error::InternalServerError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+  end
+
+  def api_return_error_code error_code, error_class
+    params = {
+      start_date: "invalid-value",
+      end_date: "invalid-value",
+      type_filter: "invalid-value"
+    }
+
+    expected_method = :get
+    expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/analytic/entity/video-quality/type"
+    expected_headers = {"Authorization" => "your-authorization"}
+    expected_query = params
+    mock_response = {
+      code: error_code,
+      message: "error message"
+    }
+
+    stub_request(expected_method, expected_url)
+      .with(headers: expected_headers, query: expected_query)
+      .to_return(body: mock_response.to_json)
+
+    expect{Uiza::Analytic.get_type params}.to raise_error do |error|
+      expect(error).to be_a error_class
+      expect(error.description_link).to eq "https://docs.uiza.io/#type"
+      expect(error.code).to eq error_code
+      expect(error.message).to eq "error message"
+    end
+
+    expect(WebMock).to have_requested(expected_method, expected_url)
+      .with(headers: expected_headers, query: expected_query)
+  end
+end


### PR DESCRIPTION
## Related Tickets

* [#225766](https://dev.framgia.com/issues/225766)

## What's this PR do ?

- [x] Analytic: get_type
- [x] spec
- [x] doc

## Library

- N/A

## Impacted Areas in Application

- N/A

## Performance

## Checklist

- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes
- N/A

## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

params = {
  start_date: "2019-01-01 00:00",
  end_date: "2019-02-01 00:00",
  type_filter: "country"
}
response = Uiza::Analytic.get_type params
response.first.name
```