### PR TITLE
225758_user_change_password

### DIFF
--- a/doc/USER.md
+++ b/doc/USER.md
@@ -137,3 +137,39 @@ Example Response
   "createdAt": "2018-06-22T02:32:29.000Z"
 }
 ```
+
+## Update password
+Update password allows Admin or User update their current password.
+
+See details [here](https://docs.uiza.io/#update-password).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+params = {
+  id: "your-user-id",
+  oldPassword: "FMpsr<4[dGPu?B#u",
+  newPassword: "S57Eb{:aMZhW=)G$"
+}
+
+begin
+  response = Uiza::User.change_password params
+  puts response.result
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "result": "ok"
+}
+```

--- a/lib/uiza/user.rb
+++ b/lib/uiza/user.rb
@@ -8,7 +8,19 @@ module Uiza
     OBJECT_API_DESCRIPTION_LINK = {
       create: "https://docs.uiza.io/#create-an-user",
       retrieve: "https://docs.uiza.io/#retrieve-an-user",
-      list: "https://docs.uiza.io/#list-all-users"
+      list: "https://docs.uiza.io/#list-all-users",
+      change_password: "https://docs.uiza.io/#update-password"
     }.freeze
+
+    class << self
+      def change_password params
+        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/changepassword"
+        method = :post
+        headers = {"Authorization" => Uiza.authorization}
+
+        uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:change_password]
+        uiza_client.execute_request
+      end
+    end
   end
 end

--- a/spec/uiza/user/change_password_spec.rb
+++ b/spec/uiza/user/change_password_spec.rb
@@ -1,0 +1,126 @@
+require "spec_helper"
+
+RSpec.describe Uiza::User do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::change_password" do
+    context "API returns code 200" do
+      it "should returns a result" do
+        params = {
+          id: "your-user-id",
+          oldPassword: "FMpsr<4[dGPu?B#u",
+          newPassword: "S57Eb{:aMZhW=)G$"
+        }
+
+        # change password
+        expected_method_1 = :post
+        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user/changepassword"
+        expected_headers_1 = {"Authorization" => "your-authorization"}
+        expected_body_1 = params
+        mock_response_1 = {
+          data: {
+            result: "ok"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+          .to_return(body: mock_response_1.to_json)
+
+        response = Uiza::User.change_password params
+
+        expect(response.result).to eq "ok"
+
+        expect(WebMock).to have_requested(expected_method_1, expected_url_1)
+          .with(headers: expected_headers_1, body: expected_body_1)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 500, Uiza::Error::InternalServerError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      params = {
+        key: "invalid-value"
+      }
+
+      expected_method = :post
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user/changepassword"
+      expected_headers = {"Authorization" => "your-authorization"}
+      expected_body = params
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::User.change_password params}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#update-password"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers, body: expected_body)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

- [#225758](https://dev.framgia.com/issues/225758)

## What's this PR do ?

- [x] change password for user
- [x] spec - change password for user
- [x] doc - change password for user

## Library
N/A

## Impacted Areas in Application
N/A

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [x] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A

## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

params = {
  id: "your-user-id",
  oldPassword: "FMpsr<4[dGPu?B#u",
  newPassword: "S57Eb{:aMZhW=)G$"
}
response = Uiza::User.change_password params
puts response.result
```
