### PR TITLE
225760_user_log_out

### DIFF
--- a/doc/USER.md
+++ b/doc/USER.md
@@ -224,3 +224,33 @@ Example Response
   "result": "ok"
 }
 ```
+
+## Log Out
+This API use to log out an user. After logged out, token will be removed.
+
+See details [here](https://docs.uiza.io/#log-out).
+
+```ruby
+require "uiza"
+
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.authorization = "your-authorization"
+
+begin
+  response = Uiza::User.logout
+  puts response.message
+rescue Uiza::Error::UizaError => e
+  puts "description_link: #{e.description_link}"
+  puts "code: #{e.code}"
+  puts "message: #{e.message}"
+rescue StandardError => e
+  puts "message: #{e.message}"
+end
+```
+
+Example Response
+```ruby
+{
+  "message": "Logout success"
+}
+```

--- a/lib/uiza/user.rb
+++ b/lib/uiza/user.rb
@@ -11,7 +11,8 @@ module Uiza
       retrieve: "https://docs.uiza.io/#retrieve-an-user",
       list: "https://docs.uiza.io/#list-all-users",
       update: "https://docs.uiza.io/#update-an-user",
-      change_password: "https://docs.uiza.io/#update-password"
+      change_password: "https://docs.uiza.io/#update-password",
+      logout: "https://docs.uiza.io/#log-out"
     }.freeze
 
     class << self
@@ -21,6 +22,16 @@ module Uiza
         headers = {"Authorization" => Uiza.authorization}
 
         uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:change_password]
+        uiza_client.execute_request
+      end
+
+      def logout
+        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/logout"
+        method = :post
+        headers = {"Authorization" => Uiza.authorization}
+        params = {}
+
+        uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:logout]
         uiza_client.execute_request
       end
     end

--- a/spec/uiza/user/logout_spec.rb
+++ b/spec/uiza/user/logout_spec.rb
@@ -1,0 +1,113 @@
+require "spec_helper"
+
+RSpec.describe Uiza::User do
+  before(:each) do
+    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.authorization = "your-authorization"
+  end
+
+  describe "::logout" do
+    context "API returns code 200" do
+      it "should returns a message" do
+        expected_method = :post
+        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user/logout"
+        expected_headers = {"Authorization" => "your-authorization"}
+        mock_response = {
+          data: {
+            message: "Logout success"
+          },
+          code: 200
+        }
+
+        stub_request(expected_method, expected_url)
+          .with(headers: expected_headers)
+          .to_return(body: mock_response.to_json)
+
+        response = Uiza::User.logout
+
+        expect(response.message).to eq "Logout success"
+
+        expect(WebMock).to have_requested(expected_method, expected_url)
+          .with(headers: expected_headers)
+      end
+    end
+
+    context "API returns code 400" do
+      it "should raise BadRequestError" do
+        api_return_error_code 400, Uiza::Error::BadRequestError
+      end
+    end
+
+    context "API returns code 401" do
+      it "should raise UnauthorizedError" do
+        api_return_error_code 401, Uiza::Error::UnauthorizedError
+      end
+    end
+
+    context "API returns code 404" do
+      it "should raise NotFoundError" do
+        api_return_error_code 404, Uiza::Error::NotFoundError
+      end
+    end
+
+    context "API returns code 422" do
+      it "should raise UnprocessableError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 500" do
+      it "should raise InternalServerError" do
+        api_return_error_code 422, Uiza::Error::UnprocessableError
+      end
+    end
+
+    context "API returns code 503" do
+      it "should raise ServiceUnavailableError" do
+        api_return_error_code 503, Uiza::Error::ServiceUnavailableError
+      end
+    end
+
+    context "API returns code 4xx (example 456)" do
+      it "should raise ClientError" do
+        api_return_error_code 456, Uiza::Error::ClientError
+      end
+    end
+
+    context "API returns code 5xx (example 567)" do
+      it "should raise ServerError" do
+        api_return_error_code 567, Uiza::Error::ServerError
+      end
+    end
+
+    context "API returns unknow code (example 345)" do
+      it "should raise UizaError" do
+        api_return_error_code 345, Uiza::Error::UizaError
+      end
+    end
+
+    def api_return_error_code error_code, error_class
+      expected_method = :post
+      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user/logout"
+      expected_headers = {"Authorization" => "your-authorization"}
+      mock_response = {
+        code: error_code,
+        message: "error message"
+      }
+
+      stub_request(expected_method, expected_url)
+        .with(headers: expected_headers)
+        .to_return(body: mock_response.to_json)
+
+      expect{Uiza::User.logout}.to raise_error do |error|
+        expect(error).to be_a error_class
+        expect(error.description_link).to eq "https://docs.uiza.io/#log-out"
+        expect(error.code).to eq error_code
+        expect(error.message).to eq "error message"
+      end
+
+      expect(WebMock).to have_requested(expected_method, expected_url)
+        .with(headers: expected_headers)
+    end
+  end
+end


### PR DESCRIPTION
## Related Tickets

- [#225760](https://dev.framgia.com/issues/225760)

## What's this PR do ?

- [x] logout
- [x] doc - logout
- [x] spec - logout
## Library
N/A
## Impacted Areas in Application
N/A

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [ ] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A
## Notes
```ruby
irb -Ilib -ruiza
Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

response = Uiza::User.logout
puts response.message
```