### PR TITLE
228200_Ruby_V4_Entity_retrieve

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    uiza (0.1.0)
+    uiza (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See details [here](https://docs.uiza.io/#authentication).
 ## Ruby
 ```ruby
 require "uiza"
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 ```
 
@@ -57,14 +57,14 @@ Uiza.authorization = "your-authorization"
 Create file `your-app/config/initializers/uiza.rb`
 
 ```ruby
-Uiza.workspace_api_domain = ENV["WORKSPACE_API_DOMAIN"]
+Uiza.app_id = ENV["APP_ID"]
 Uiza.authorization = ENV["AUTHORIZATION"]
 ```
 
 ## Entity
 These below APIs used to take action with your media files (we called Entity).
 
-See details [here](https://github.com/uizaio/api-wrapper-ruby/blob/master/doc/ENTITY.md).
+See details [here](https://github.com/uizaio/api-wrapper-ruby/blob/develop/doc/ENTITY.md).
 
 ```ruby
 begin

--- a/lib/uiza.rb
+++ b/lib/uiza.rb
@@ -37,7 +37,7 @@ module Uiza
     attr_accessor :app_id, :authorization
 
     def workspace_api_domain
-      "https://stag-ap-southeast-1-api.uizadev.io"
+      "stag-ap-southeast-1-api.uizadev.io"
     end
 
     def api_version

--- a/lib/uiza/api_operation/retrieve.rb
+++ b/lib/uiza/api_operation/retrieve.rb
@@ -2,10 +2,10 @@ module Uiza
   module APIOperation
     module Retrieve
       def retrieve id
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{self::OBJECT_API_PATH}"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{self::OBJECT_API_PATH}"
         method = :get
         headers = {"Authorization" => Uiza.authorization}
-        params = {id: id}
+        params = {id: id, appId: Uiza.app_id}
 
         uiza_client = UizaClient.new url, method, headers, params, self::OBJECT_API_DESCRIPTION_LINK[:retrieve]
         uiza_client.execute_request

--- a/spec/uiza/entity/retrieve_spec.rb
+++ b/spec/uiza/entity/retrieve_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Entity do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -12,9 +12,9 @@ RSpec.describe Uiza::Entity do
         id = "your-entity-id"
 
         expected_method = :get
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_query = {id: id}
+        expected_query = {id: id, appId: "your-app-id"}
         mock_response = {
           data: {
             id: "your-entity-id",
@@ -103,9 +103,9 @@ RSpec.describe Uiza::Entity do
       id = "invalid-entity-id"
 
       expected_method = :get
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_query = {id: id}
+      expected_query = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets
- https://dev.framgia.com/issues/228200

## What's this PR do ?
- [x] Implement API V4 Retrieve entity

## Library

## Performance

## Checklist
- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes

## Notes
```ruby
require "uiza"

Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
Uiza.authorization = "your-authorization"

begin
  entity = Uiza::Entity.retrieve "your-entity-id"
  puts entity.id
  puts entity.name
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```