### PR TITLE
228197_Ruby_V4_Entity_create

### DIFF
--- a/doc/ENTITY.md
+++ b/doc/ENTITY.md
@@ -11,7 +11,7 @@ See details [here](https://docs.uiza.io/#create-entity).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 params = {

--- a/lib/uiza/api_operation/create.rb
+++ b/lib/uiza/api_operation/create.rb
@@ -2,9 +2,10 @@ module Uiza
   module APIOperation
     module Create
       def create params
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{self::OBJECT_API_PATH}"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{self::OBJECT_API_PATH}"
         method = :post
         headers = {"Authorization" => Uiza.authorization}
+        params["appId"] = Uiza.app_id
 
         uiza_client = UizaClient.new url, method, headers, params, self::OBJECT_API_DESCRIPTION_LINK[:create]
         response = uiza_client.execute_request

--- a/spec/uiza/entity/create_spec.rb
+++ b/spec/uiza/entity/create_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Entity do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -17,9 +17,9 @@ RSpec.describe Uiza::Entity do
 
         # create entity
         expected_method_1 = :post
-        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity"
+        expected_url_1 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity"
         expected_headers_1 = {"Authorization" => "your-authorization"}
-        expected_body_1 = params
+        expected_body_1 = params.merge!(appId: "your-app-id")
         mock_response_1 = {
           data: {
             id: "your-entity-id"
@@ -33,9 +33,9 @@ RSpec.describe Uiza::Entity do
 
         # retrieve entity with id = "your-entity-id"
         expected_method_2 = :get
-        expected_url_2 = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity"
+        expected_url_2 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity"
         expected_headers_2 = {"Authorization" => "your-authorization"}
-        expected_query_2 = {id: "your-entity-id"}
+        expected_query_2 = {id: "your-entity-id", appId: "your-app-id"}
         mock_response_2 = {
           data: {
             id: "your-entity-id",
@@ -129,9 +129,9 @@ RSpec.describe Uiza::Entity do
       }
 
       expected_method = :post
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = params
+      expected_body = params.merge(appId: "your-app-id")
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets
- https://dev.framgia.com/issues/228197

## What's this PR do ?
- [x] Implement API V4 Create Entity

## Library

## Impacted Areas in Application
## Performance

## Checklist
- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes

## Notes
```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

params = {
  name: "Sample Video",
  url: "https://example.com/video.mp4",
  inputType: "http",
  description: "Lorem Ipsum is simply dummy text of the printing and typesetting industry.",
  shortDescription: "Lorem Ipsum is simply dummy text.",
  poster: "https://example.com/picture001.jpeg",
  thumbnail: "https://example.com/picture002.jpeg"
}

begin
  entity = Uiza::Entity.create params
  puts entity.id
  puts entity.name
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```