### PR TITLE
228336_Ruby_V4_Entity_publish

### DIFF
--- a/doc/ENTITY.md
+++ b/doc/ENTITY.md
@@ -269,7 +269,7 @@ See details [here](https://docs.uiza.io/#delete-an-entity).
 ```ruby
 require "uiza"
 
-Uiza.app_id = "your-app-id"
+Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
 Uiza.authorization = "your-authorization"
 
 begin
@@ -377,7 +377,7 @@ See details [here](https://docs.uiza.io/#publish-entity-to-cdn).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/lib/uiza/entity.rb
+++ b/lib/uiza/entity.rb
@@ -32,10 +32,10 @@ module Uiza
       end
 
       def publish id
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/publish"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{OBJECT_API_PATH}/publish"
         method = :post
         headers = {"Authorization" => Uiza.authorization}
-        params = {id: id}
+        params = {id: id, appId: Uiza.app_id}
         description_link = OBJECT_API_DESCRIPTION_LINK[:publish]
 
         uiza_client = UizaClient.new url, method, headers, params, description_link

--- a/spec/uiza/entity/publish_spec.rb
+++ b/spec/uiza/entity/publish_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Entity do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -12,9 +12,9 @@ RSpec.describe Uiza::Entity do
         id = "your-entity-id"
 
         expected_method = :post
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/publish"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity/publish"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_body = {id: id}
+        expected_body = {id: id, appId: "your-app-id"}
         mock_response = {
           data: {
             message: "Your entity started publish, check process status with this entity ID",
@@ -95,9 +95,9 @@ RSpec.describe Uiza::Entity do
       id = "invalid-entity-id"
 
       expected_method = :post
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/publish"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity/publish"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = {id: id}
+      expected_body = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets
- https://dev.framgia.com/issues/228336

## What's this PR do ?
- [x] Implement API Publish entity to CDN

## Library

## Impacted Areas in Application

## Performance

## Checklist
- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes

## Notes
```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  response = Uiza::Entity.publish "your-entity-id"
  puts response.message
  puts response.entityId
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```