### PR TITLE
228341_Ruby_V4_Entity_get_status_public

### DIFF
--- a/doc/ENTITY.md
+++ b/doc/ENTITY.md
@@ -409,7 +409,7 @@ See details [here](https://docs.uiza.io/#get-status-publish).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/lib/uiza/entity.rb
+++ b/lib/uiza/entity.rb
@@ -43,10 +43,10 @@ module Uiza
       end
 
       def get_status_publish id
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/publish/status"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{OBJECT_API_PATH}/publish/status"
         method = :get
         headers = {"Authorization" => Uiza.authorization}
-        params = {id: id}
+        params = {id: id, appId: Uiza.app_id}
         description_link = OBJECT_API_DESCRIPTION_LINK[:get_status_publish]
 
         uiza_client = UizaClient.new url, method, headers, params, description_link

--- a/spec/uiza/entity/get_status_publish_spec.rb
+++ b/spec/uiza/entity/get_status_publish_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Entity do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -12,9 +12,9 @@ RSpec.describe Uiza::Entity do
         id = "your-entity-id"
 
         expected_method = :get
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/publish/status"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity/publish/status"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_query = {id: id}
+        expected_query = {id: id, appId: "your-app-id"}
         mock_response = {
           data: {
             status: "success",
@@ -95,9 +95,9 @@ RSpec.describe Uiza::Entity do
       id = "invalid-entity-id"
 
       expected_method = :get
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/publish/status"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity/publish/status"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_query = {id: id}
+      expected_query = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets
- https://dev.framgia.com/issues/228341

## What's this PR do ?
- [x] Implement API Entity get status publish

## Library

## Impacted Areas in Application

## Performance

## Checklist
- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes

## Notes
```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  response = Uiza::Entity.get_status_publish "your-entity-id"
  puts response.progress
  puts response.status
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```