### PR TITLE
228344_Ruby_v4_get_aws_upload_key

### DIFF
--- a/doc/ENTITY.md
+++ b/doc/ENTITY.md
@@ -269,7 +269,7 @@ See details [here](https://docs.uiza.io/#delete-an-entity).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin
@@ -441,7 +441,7 @@ See details [here](https://docs.uiza.io/#get-aws-upload-key).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/lib/uiza/entity.rb
+++ b/lib/uiza/entity.rb
@@ -54,10 +54,10 @@ module Uiza
       end
 
       def get_aws_upload_key
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/admin/app/config/aws"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/admin/app/config/aws"
         method = :get
         headers = {"Authorization" => Uiza.authorization}
-        params = {}
+        params = {"appId" => Uiza.app_id}
         description_link = OBJECT_API_DESCRIPTION_LINK[:get_aws_upload_key]
 
         uiza_client = UizaClient.new url, method, headers, params, description_link

--- a/spec/uiza/entity/get_aws_upload_key_spec.rb
+++ b/spec/uiza/entity/get_aws_upload_key_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Entity do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -10,8 +10,9 @@ RSpec.describe Uiza::Entity do
     context "API returns code 200" do
       it "should returns an object with aws data" do
         expected_method = :get
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/app/config/aws"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/admin/app/config/aws"
         expected_headers = {"Authorization" => "your-authorization"}
+        expected_query = {"appId" => "your-app-id"}
         mock_response = {
           data: {
             bucket_name: "Sample bucket name",
@@ -21,7 +22,7 @@ RSpec.describe Uiza::Entity do
         }
 
         stub_request(expected_method, expected_url)
-          .with(headers: expected_headers)
+          .with(headers: expected_headers, query: expected_query)
           .to_return(body: mock_response.to_json)
 
         response = Uiza::Entity.get_aws_upload_key
@@ -30,7 +31,7 @@ RSpec.describe Uiza::Entity do
         expect(response.region_name).to eq "Sample region name"
 
         expect(WebMock).to have_requested(expected_method, expected_url)
-          .with(headers: expected_headers)
+          .with(headers: expected_headers, query: expected_query)
       end
     end
 
@@ -90,15 +91,16 @@ RSpec.describe Uiza::Entity do
 
     def api_return_error_code error_code, error_class
       expected_method = :get
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/app/config/aws"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/admin/app/config/aws"
       expected_headers = {"Authorization" => "your-authorization"}
+      expected_query = {"appId" => "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"
       }
 
       stub_request(expected_method, expected_url)
-        .with(headers: expected_headers)
+        .with(headers: expected_headers, query: expected_query)
         .to_return(body: mock_response.to_json)
 
       expect{Uiza::Entity.get_aws_upload_key}.to raise_error do |error|
@@ -109,7 +111,7 @@ RSpec.describe Uiza::Entity do
       end
 
       expect(WebMock).to have_requested(expected_method, expected_url)
-        .with(headers: expected_headers)
+        .with(headers: expected_headers, query: expected_query)
     end
   end
 end


### PR DESCRIPTION
## Related Tickets
- https://dev.framgia.com/issues/228344

## What's this PR do ?
- [x] Implement API Entity get aws upload key

## Library

## Impacted Areas in Application

## Performance

## Checklist
- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes

## Notes
```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  response = Uiza::Entity.get_aws_upload_key
  puts response.bucket_name
  puts response.region_name
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```