### PR TITLE
228468_category_retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ end
 ## Category
 Category has been splits into 3 types: `folder`, `playlist` and `tag`. These will make the management of entity more easier.
 
-See details [here](https://github.com/uizaio/api-wrapper-ruby/blob/master/doc/CATEGORY.md).
+See details [here](https://github.com/uizaio/api-wrapper-ruby/blob/develop/doc/CATEGORY.md).
 
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/doc/CATEGORY.md
+++ b/doc/CATEGORY.md
@@ -59,7 +59,7 @@ See details [here](https://docs.uiza.io/?shell#retrieve-category).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/spec/uiza/category/retrieve_spec.rb
+++ b/spec/uiza/category/retrieve_spec.rb
@@ -2,19 +2,19 @@ require "spec_helper"
 
 RSpec.describe Uiza::Category do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
   describe "::retrieve" do
     context "API returns code 200" do
-      it "should returns an category" do
+      it "should returns a category" do
         id = "your-category-id"
 
         expected_method = :get
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/metadata"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/metadata"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_query = {id: id}
+        expected_query = {id: id, appId: "your-app-id"}
         mock_response = {
           data: {
             id: "your-category-id",
@@ -103,9 +103,9 @@ RSpec.describe Uiza::Category do
       id = "invalid-category-id"
 
       expected_method = :get
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/metadata"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/metadata"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_query = {id: id}
+      expected_query = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets

- [#228468](https://dev.framgia.com/issues/228468)

## What's this PR do ?

- [x] update doc
- [x] update rspec

## Library
N/A
## Impacted Areas in Application
N/A
## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [x] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A

## Notes
```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  category = Uiza::Category.retrieve "your-category-id"
  puts category.id
  puts category.name
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```