### PR TITLE
228478_ruby_v4_Storage_add

### DIFF
--- a/doc/STORAGE.md
+++ b/doc/STORAGE.md
@@ -13,7 +13,7 @@ See details [here](https://docs.uiza.io/#add-a-storage).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 params = {

--- a/lib/uiza/api_operation/add.rb
+++ b/lib/uiza/api_operation/add.rb
@@ -2,9 +2,10 @@ module Uiza
   module APIOperation
     module Add
       def add params
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{self::OBJECT_API_PATH}"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{self::OBJECT_API_PATH}"
         method = :post
         headers = {"Authorization" => Uiza.authorization}
+        params["appId"] = Uiza.app_id
 
         uiza_client = UizaClient.new url, method, headers, params, self::OBJECT_API_DESCRIPTION_LINK[:add]
         response = uiza_client.execute_request

--- a/spec/uiza/storage/add_spec.rb
+++ b/spec/uiza/storage/add_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Storage do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -19,9 +19,9 @@ RSpec.describe Uiza::Storage do
 
         # add storage
         expected_method_1 = :post
-        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+        expected_url_1 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
         expected_headers_1 = {"Authorization" => "your-authorization"}
-        expected_body_1 = params
+        expected_body_1 = params.merge!(appId: "your-app-id")
         mock_response_1 = {
           data: {
             id: "your-storage-id"
@@ -35,7 +35,7 @@ RSpec.describe Uiza::Storage do
 
         # retrieve storage with id = "your-storage-id"
         expected_method_2 = :get
-        expected_url_2 = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+        expected_url_2 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
         expected_headers_2 = {"Authorization" => "your-authorization"}
         expected_query_2 = {id: "your-storage-id"}
         mock_response_2 = {
@@ -131,9 +131,9 @@ RSpec.describe Uiza::Storage do
       }
 
       expected_method = :post
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = params
+      expected_body = params.merge(appId: "your-app-id")
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets

- [#228478](https://dev.framgia.com/issues/228478)

## What's this PR do ?
- Storage: add
- Doc
- Spec
## Library
- N/A
## Impacted Areas in Application
- N/A
## Performance
- N/A
## Checklist
- N/A
## Notes

```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

params = {
  name: "FTP Uiza",
  description: "FTP of Uiza, use for transcode",
  storageType: "ftp",
  host: "ftp-example.uiza.io"
}

begin
  storage = Uiza::Storage.add params
  puts storage.id
  puts storage.name
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```