### PR TITLE
228479_ruby_v4_Storage_remove

### DIFF
--- a/doc/STORAGE.md
+++ b/doc/STORAGE.md
@@ -165,7 +165,7 @@ See details [here](https://docs.uiza.io/#remove-storage).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/lib/uiza/api_operation/remove.rb
+++ b/lib/uiza/api_operation/remove.rb
@@ -2,10 +2,10 @@ module Uiza
   module APIOperation
     module Remove
       def remove id
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{self::OBJECT_API_PATH}"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{self::OBJECT_API_PATH}"
         method = :delete
         headers = {"Authorization" => Uiza.authorization}
-        params = {id: id}
+        params = {id: id, appId: Uiza.app_id}
 
         uiza_client = UizaClient.new url, method, headers, params, self::OBJECT_API_DESCRIPTION_LINK[:remove]
         uiza_client.execute_request

--- a/spec/uiza/storage/remove_spec.rb
+++ b/spec/uiza/storage/remove_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Storage do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -12,9 +12,9 @@ RSpec.describe Uiza::Storage do
         id = "your-storage-id"
 
         expected_method = :delete
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_body = {id: id}
+        expected_body = {id: id, appId: "your-app-id"}
         mock_response = {
           data: {
             id: "your-storage-id"
@@ -93,9 +93,9 @@ RSpec.describe Uiza::Storage do
       id = "invalid-storage-id"
 
       expected_method = :delete
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = {id: id}
+      expected_body = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets

- [#228478](https://dev.framgia.com/issues/228478)

## What's this PR do ?
- Storage: add
- Doc
- Spec
## Library
- N/A
## Impacted Areas in Application
- N/A
## Performance
- N/A
## Checklist
- N/A
## Notes

```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  storage = Uiza::Storage.remove "your-storage-id"
  puts storage.id
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```