### PR TITLE
228480_Ruby_V4_Storage_update

### DIFF
--- a/doc/STORAGE.md
+++ b/doc/STORAGE.md
@@ -111,7 +111,7 @@ See details [here](https://docs.uiza.io/#update-storage).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 params = {

--- a/spec/uiza/storage/add_spec.rb
+++ b/spec/uiza/storage/add_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Uiza::Storage do
         expected_method_2 = :get
         expected_url_2 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
         expected_headers_2 = {"Authorization" => "your-authorization"}
-        expected_query_2 = {id: "your-storage-id"}
+        expected_query_2 = {id: "your-storage-id", appId: "your-app-id"}
         mock_response_2 = {
           data: {
             id: "your-storage-id",

--- a/spec/uiza/storage/update_spec.rb
+++ b/spec/uiza/storage/update_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Storage do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -20,9 +20,9 @@ RSpec.describe Uiza::Storage do
 
         # update storage
         expected_method_1 = :put
-        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+        expected_url_1 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
         expected_headers_1 = {"Authorization" => "your-authorization"}
-        expected_body_1 = params
+        expected_body_1 = params.merge!(appId: "your-app-id")
         mock_response_1 = {
           data: {
             id: "your-storage-id"
@@ -36,9 +36,9 @@ RSpec.describe Uiza::Storage do
 
         # retrieve storage with id = "your-storage-id"
         expected_method_2 = :get
-        expected_url_2 = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+        expected_url_2 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
         expected_headers_2 = {"Authorization" => "your-authorization"}
-        expected_query_2 = {id: "your-storage-id"}
+        expected_query_2 = {id: "your-storage-id", appId: "your-app-id"}
         mock_response_2 = {
           data: {
             id: "your-storage-id",
@@ -129,9 +129,9 @@ RSpec.describe Uiza::Storage do
       }
 
       expected_method = :put
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = params
+      expected_body = params.merge(appId: "your-app-id")
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets

- [#228480](https://dev.framgia.com/issues/228480)

## What's this PR do ?
- Storage: Update
- Doc
- Spec
## Library
- N/A
## Impacted Areas in Application
- N/A
## Performance
- N/A
## Checklist
- N/A
## Notes

```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

params = {
  id: "your-storage-id",
  name: "FTP Uiza edited",
  host: "ftp-example.uiza.io",
  port: 21,
  storageType: "ftp"
}

begin
  storage = Uiza::Storage.update params
  puts storage.id
  puts storage.name
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```