### PR TITLE
228481_Ruby_V4_Storage_retrieve

### DIFF
--- a/doc/STORAGE.md
+++ b/doc/STORAGE.md
@@ -65,7 +65,7 @@ See details [here](https://docs.uiza.io/#retrieve-a-storage).
 
 ```ruby
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/spec/uiza/storage/retrieve_spec.rb
+++ b/spec/uiza/storage/retrieve_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Storage do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -12,9 +12,9 @@ RSpec.describe Uiza::Storage do
         id = "your-storage-id"
 
         expected_method = :get
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_query = {id: id}
+        expected_query = {id: id, appId: "your-app-id"}
         mock_response = {
           data: {
             id: "your-storage-id",
@@ -103,9 +103,9 @@ RSpec.describe Uiza::Storage do
       id = "invalid-storage-id"
 
       expected_method = :get
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/storage"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/storage"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_query = {id: id}
+      expected_query = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets

- [#228481](https://dev.framgia.com/issues/228481)

## What's this PR do ?
- Storage: Retrieve
- Doc
- Spec
## Library
- N/A
## Impacted Areas in Application
- N/A
## Performance
- N/A
## Checklist
- N/A
## Notes

```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  storage = Uiza::Storage.retrieve "your-storage-id"
  puts storage.id
  puts storage.name
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```