### PR TITLE
228475_v4_category_delete_relation

### DIFF
--- a/doc/CATEGORY.md
+++ b/doc/CATEGORY.md
@@ -274,7 +274,7 @@ See details [here](https://docs.uiza.io/#delete-category-relation).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 params = {

--- a/lib/uiza/category.rb
+++ b/lib/uiza/category.rb
@@ -29,10 +29,11 @@ module Uiza
       end
 
       def delete_relation params
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/media/entity/related/metadata"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/media/entity/related/metadata"
         method = :post
         headers = {"Authorization" => Uiza.authorization}
         description_link = OBJECT_API_DESCRIPTION_LINK[:delete_relation]
+        params["appId"] = Uiza.app_id
 
         uiza_client = UizaClient.new url, method, headers, params, description_link
         uiza_client.execute_request

--- a/spec/uiza/category/delete_relation_spec.rb
+++ b/spec/uiza/category/delete_relation_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Category do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -11,11 +11,12 @@ RSpec.describe Uiza::Category do
       it "should returns an array of relations" do
         params = {
           entityId: "your-entity-id-01",
-          metadataIds: ["your-category-id-01", "your-category-id-02"]
+          metadataIds: ["your-category-id-01", "your-category-id-02"],
+          appId: "your-app-id"
         }
 
         expected_method = :post
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/related/metadata"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity/related/metadata"
         expected_headers = {"Authorization" => "your-authorization"}
         expected_body = params
         mock_response = {
@@ -104,11 +105,12 @@ RSpec.describe Uiza::Category do
   def api_return_error_code error_code, error_class
     params = {
       entityId: "your-entity-id-01",
-      metadataIds: ["your-category-id-01", "your-category-id-02"]
+      metadataIds: ["your-category-id-01", "your-category-id-02"],
+      appId: "your-app-id"
     }
 
     expected_method = :post
-    expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/related/metadata"
+    expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity/related/metadata"
     expected_headers = {"Authorization" => "your-authorization"}
     expected_body = params
     mock_response = {


### PR DESCRIPTION
## Related Tickets

- [#228475](https://dev.framgia.com/issues/228475)

## What's this PR do ?

- [x] update doc
- [x] update spec
- [x] update function delete category relation

## Library
N/A

## Impacted Areas in Application
N/A

## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [x] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A

## Notes
```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

params = {
  entityId: "your-entity-id",
  metadataIds: ["your-category-id-1", "your-category-id-2"]
}

begin
  relations = Uiza::Category.delete_relation params
  puts relations.first.id
  puts relations.first.entityId
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```
