### PR TITLE
228487_Ruby_V4_Live_stop_feed

### DIFF
--- a/doc/LIVE_STREAMING.md
+++ b/doc/LIVE_STREAMING.md
@@ -262,7 +262,7 @@ See details [here](https://docs.uiza.io/#stop-a-live-feed).
 
 ```ruby
 require "uiza"
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/lib/uiza/live.rb
+++ b/lib/uiza/live.rb
@@ -42,10 +42,10 @@ module Uiza
       end
 
       def stop_feed id
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/feed"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{OBJECT_API_PATH}/feed"
         method = :put
         headers = {"Authorization" => Uiza.authorization}
-        params = {id: id}
+        params = {id: id, appId: Uiza.app_id}
 
         uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:stop_feed]
         response = uiza_client.execute_request

--- a/spec/uiza/live/stop_feed_spec.rb
+++ b/spec/uiza/live/stop_feed_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Live do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -13,9 +13,9 @@ RSpec.describe Uiza::Live do
 
         # stop a live feed
         expected_method_1 = :put
-        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity/feed"
+        expected_url_1 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/live/entity/feed"
         expected_headers_1 = {"Authorization" => "your-authorization"}
-        expected_body_1 = {id: id}
+        expected_body_1 = {id: id, appId: "your-app-id"}
         mock_response_1 = {
           data: {
             entityId: "your-live-id"
@@ -29,9 +29,9 @@ RSpec.describe Uiza::Live do
 
         # retrieve live with id = "your-live-id"
         expected_method_2 = :get
-        expected_url_2 = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity"
+        expected_url_2 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/live/entity"
         expected_headers_2 = {"Authorization" => "your-authorization"}
-        expected_query_2 = {id: "your-live-id"}
+        expected_query_2 = {id: "your-live-id", appId: "your-app-id"}
         mock_response_2 = {
           data: {
             id: "your-live-id",
@@ -125,9 +125,9 @@ RSpec.describe Uiza::Live do
       id = "invalid-value"
 
       expected_method = :put
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity/feed"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/live/entity/feed"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = {id: id}
+      expected_body = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets
- https://dev.framgia.com/issues/228487

## What's this PR do ?
- [x] Implement API live stop feed

## Library

## Impacted Areas in Application

## Performance

## Checklist
- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes

## Notes
```ruby
require "uiza"
Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  live = Uiza::Live.stop_feed "your-live-id"
  puts live.id
  puts live.name
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```