### PR TITLE
228496_v4_callback_delete

### DIFF
--- a/doc/CALLBACK.md
+++ b/doc/CALLBACK.md
@@ -138,7 +138,7 @@ See details [here](https://docs.uiza.io/#delete-a-callback).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/spec/uiza/callback/delete_spec.rb
+++ b/spec/uiza/callback/delete_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Callback do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -12,9 +12,9 @@ RSpec.describe Uiza::Callback do
         id = "your-callback-id"
 
         expected_method = :delete
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity/callback"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_body = {id: id}
+        expected_body = {id: id, appId: "your-app-id"}
         mock_response = {
           data: {
             id: "your-callback-id"
@@ -93,9 +93,9 @@ RSpec.describe Uiza::Callback do
       id = "invalid-callback-id"
 
       expected_method = :delete
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/media/entity/callback"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/media/entity/callback"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = {id: id}
+      expected_body = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets

- [#228496](https://dev.framgia.com/issues/228496)

## What's this PR do ?

- [x] update doc
- [x] update spec

## Library
N/A

## Impacted Areas in Application
N/A
## Performance

- [ ] Resolved n + 1 query
- [ ] Run explain query already
- [ ] Time run rake task : 1000 ms

## Checklist

- [x] It was tested in local success?
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API

## Deploy Notes
N/A
## Notes
```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  callback = Uiza::Callback.delete "your-callback-id"
  puts callback.id
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```
