### PR TITLE
228491_Ruby_V4_Entity_delete

### DIFF
--- a/doc/LIVE_STREAMING.md
+++ b/doc/LIVE_STREAMING.md
@@ -375,7 +375,7 @@ See details [here](https://docs.uiza.io/#delete-a-record-file).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/lib/uiza/live.rb
+++ b/lib/uiza/live.rb
@@ -64,10 +64,10 @@ module Uiza
       end
 
       def delete id
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/dvr"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{OBJECT_API_PATH}/dvr"
         method = :delete
         headers = {"Authorization" => Uiza.authorization}
-        params = {id: id}
+        params = {id: id, appId: Uiza.app_id}
 
         uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:delete]
         uiza_client.execute_request

--- a/spec/uiza/live/delete_spec.rb
+++ b/spec/uiza/live/delete_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::Live do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -12,9 +12,9 @@ RSpec.describe Uiza::Live do
         id = "your-record-id"
 
         expected_method = :delete
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity/dvr"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/live/entity/dvr"
         expected_headers = {"Authorization" => "your-authorization"}
-        expected_body = {id: id}
+        expected_body = {id: id, appId: "your-app-id"}
         mock_response = {
           data: {
             id: "your-record-id"
@@ -93,9 +93,9 @@ RSpec.describe Uiza::Live do
       id = "invalid-record-id"
 
       expected_method = :delete
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/live/entity/dvr"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/live/entity/dvr"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = {id: id}
+      expected_body = {id: id, appId: "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets
- https://dev.framgia.com/issues/228491

## What's this PR do ?
- [x] Implement API delete Live

## Library

## Impacted Areas in Application

## Performance

## Checklist
- [x] It was tested in local success?
- [x] Fill link PR into ticket and the opposite
- [x] Note reason, scope of influence, solution into ticket
- [x] Validate UI/Model/API

## Deploy Notes

## Notes
```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  live = Uiza::Live.delete "your-record-id" #Identifier of record (get from list record)
  puts live.id
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```