### PR TITLE
228504_Ruby_V4_user_update_password

### DIFF
--- a/doc/USER.md
+++ b/doc/USER.md
@@ -227,7 +227,7 @@ See details [here](https://docs.uiza.io/#update-password).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 params = {

--- a/lib/uiza/user.rb
+++ b/lib/uiza/user.rb
@@ -19,9 +19,10 @@ module Uiza
 
     class << self
       def change_password params
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/changepassword"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{OBJECT_API_PATH}/changepassword"
         method = :post
         headers = {"Authorization" => Uiza.authorization}
+        params["appId"] = Uiza.app_id
 
         uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:change_password]
         uiza_client.execute_request

--- a/spec/uiza/user/change_password_spec.rb
+++ b/spec/uiza/user/change_password_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::User do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -17,9 +17,9 @@ RSpec.describe Uiza::User do
 
         # change password
         expected_method_1 = :post
-        expected_url_1 = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user/changepassword"
+        expected_url_1 = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/admin/user/changepassword"
         expected_headers_1 = {"Authorization" => "your-authorization"}
-        expected_body_1 = params
+        expected_body_1 = params.merge!(appId: "your-app-id")
         mock_response_1 = {
           data: {
             result: "ok"
@@ -100,9 +100,9 @@ RSpec.describe Uiza::User do
       }
 
       expected_method = :post
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user/changepassword"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/admin/user/changepassword"
       expected_headers = {"Authorization" => "your-authorization"}
-      expected_body = params
+      expected_body = params.merge!(appId: "your-app-id")
       mock_response = {
         code: error_code,
         message: "error message"


### PR DESCRIPTION
## Related Tickets

- [#228504](https://dev.framgia.com/issues/228504)

## What's this PR do ?
- User: change password
- Doc
- Spec
## Library
- N/A
## Impacted Areas in Application
- N/A
## Performance
- N/A
## Checklist
- N/A
## Notes

```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

params = {
  id: "your-user-id",
  oldPassword: "FMpsr<4[dGPu?B#u",
  newPassword: "S57Eb{:aMZhW=)G$"
}

begin
  response = Uiza::User.change_password params
  puts response.result
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```