### PR TITLE
228501_Ruby_V4_user_logout

### DIFF
--- a/doc/USER.md
+++ b/doc/USER.md
@@ -263,7 +263,7 @@ See details [here](https://docs.uiza.io/#log-out).
 ```ruby
 require "uiza"
 
-Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+Uiza.app_id = "your-app-id"
 Uiza.authorization = "your-authorization"
 
 begin

--- a/lib/uiza/user.rb
+++ b/lib/uiza/user.rb
@@ -29,10 +29,10 @@ module Uiza
       end
 
       def logout
-        url = "https://#{Uiza.workspace_api_domain}/api/public/v3/#{OBJECT_API_PATH}/logout"
+        url = "https://#{Uiza.workspace_api_domain}/api/public/#{Uiza.api_version}/#{OBJECT_API_PATH}/logout"
         method = :post
         headers = {"Authorization" => Uiza.authorization}
-        params = {}
+        params = {appId: Uiza.app_id}
 
         uiza_client = UizaClient.new url, method, headers, params, OBJECT_API_DESCRIPTION_LINK[:logout]
         uiza_client.execute_request

--- a/spec/uiza/user/logout_spec.rb
+++ b/spec/uiza/user/logout_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Uiza::User do
   before(:each) do
-    Uiza.workspace_api_domain = "your-workspace-api-domain.uiza.co"
+    Uiza.app_id = "your-app-id"
     Uiza.authorization = "your-authorization"
   end
 
@@ -10,8 +10,9 @@ RSpec.describe Uiza::User do
     context "API returns code 200" do
       it "should returns a message" do
         expected_method = :post
-        expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user/logout"
+        expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/admin/user/logout"
         expected_headers = {"Authorization" => "your-authorization"}
+        expected_body = {"appId" => "your-app-id"}
         mock_response = {
           data: {
             message: "Logout success"
@@ -20,7 +21,7 @@ RSpec.describe Uiza::User do
         }
 
         stub_request(expected_method, expected_url)
-          .with(headers: expected_headers)
+          .with(headers: expected_headers, body: expected_body)
           .to_return(body: mock_response.to_json)
 
         response = Uiza::User.logout
@@ -28,7 +29,7 @@ RSpec.describe Uiza::User do
         expect(response.message).to eq "Logout success"
 
         expect(WebMock).to have_requested(expected_method, expected_url)
-          .with(headers: expected_headers)
+          .with(headers: expected_headers, body: expected_body)
       end
     end
 
@@ -88,15 +89,16 @@ RSpec.describe Uiza::User do
 
     def api_return_error_code error_code, error_class
       expected_method = :post
-      expected_url = "https://your-workspace-api-domain.uiza.co/api/public/v3/admin/user/logout"
+      expected_url = "https://stag-ap-southeast-1-api.uizadev.io/api/public/v4/admin/user/logout"
       expected_headers = {"Authorization" => "your-authorization"}
+      expected_body = {"appId" => "your-app-id"}
       mock_response = {
         code: error_code,
         message: "error message"
       }
 
       stub_request(expected_method, expected_url)
-        .with(headers: expected_headers)
+        .with(headers: expected_headers, body: expected_body)
         .to_return(body: mock_response.to_json)
 
       expect{Uiza::User.logout}.to raise_error do |error|


### PR DESCRIPTION
## Related Tickets

- [#228501](https://dev.framgia.com/issues/228501)

## What's this PR do ?
- User: logout
- Doc
- Spec
## Library
- N/A
## Impacted Areas in Application
- N/A
## Performance
- N/A
## Checklist
- N/A
## Notes

```ruby
require "uiza"

Uiza.app_id = "your-app-id"
Uiza.authorization = "your-authorization"

begin
  response = Uiza::User.logout
  puts response.message
rescue Uiza::Error::UizaError => e
  puts "description_link: #{e.description_link}"
  puts "code: #{e.code}"
  puts "message: #{e.message}"
rescue StandardError => e
  puts "message: #{e.message}"
end
```